### PR TITLE
fix: bump godot core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ single-thread = ["tokio/rt"]
 multi-thread = ["tokio/rt-multi-thread"]
 
 [dependencies]
-godot = "0.2.0"
+godot = "0.2.4"
 tokio = "1.32.0"


### PR DESCRIPTION
This pull request updates the dependency version for `godot` in the `Cargo.toml` file to ensure compatibility with the latest features and bug fixes.

Dependency update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L19-R19): Updated the `godot` dependency from version `0.2.0` to `0.2.4` to leverage improvements and maintain compatibility.